### PR TITLE
fix: workaround for wss port

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -329,7 +329,11 @@ func (tr *mwssTransporter) initSession(addr string, conn net.Conn, opts *Handsha
 	if path == "" {
 		path = defaultWSPath
 	}
-	url := url.URL{Scheme: "wss", Host: opts.Host, Path: path}
+	host, port, _ := net.SplitHostPort(opts.Host)
+	if port != "443" {
+		host = opts.Host
+	}
+	url := url.URL{Scheme: "wss", Host: host, Path: path}
 	conn, err := websocketClientConn(url.String(), conn, tlsConfig, wsOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When gost initiate a WebSocket connection with arguments like `-F wss://matrix.moe:443` (port is required), it will set `Host: matrix.moe:443` in request header, which leads to a failed connection in some cases. This workaround removed the port in `Host` field when the port is the default port for `wss` transport protocol.